### PR TITLE
Resolve sdists and pep517

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,5 +1,5 @@
 [packages]
-passa = { editable = true, path = '.' }
+passa = {editable = true, extras = ["tests"], path = "."}
 
 [dev-packages]
 black = '*'
@@ -18,7 +18,6 @@ passa-remove = 'python -m passa.cli.remove'
 passa-upgrade = 'python -m passa.cli.upgrade'
 passa-lock = 'python -m passa.cli.lock'
 passa-freeze = 'python -m passa.cli.freeze'
-
 black = 'black src/passa/ --exclude "/(\.git|\.hg|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist)/"'
 build = 'inv build'
 changelog = 'towncrier'

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ff353680e286436d85c9b1b00ccb7ee257cb2922a1eec0becf9713817605d92b"
+            "sha256": "f7b5223a036e80ef873ebf5df11f61827a30694d2140289ae4e550e75d10c5d7"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,14 @@
         ]
     },
     "default": {
+        "apipkg": {
+            "hashes": [
+                "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
+                "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.5"
+        },
         "appdirs": {
             "hashes": [
                 "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
@@ -22,13 +30,21 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' or python_version >= '3.6'",
             "version": "==1.4.3"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.1"
+        },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' or python_version >= '3.6'",
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "backports-shutil-get-terminal-size": {
             "hashes": [
@@ -67,6 +83,51 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.0.4"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and sys_platform == 'win32'",
+            "version": "==0.3.9"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
+                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
+                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
+                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
+                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
+                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
+                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
+                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
+                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
+                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
+                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
+                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
+                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
+                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
+                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
+                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
+                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
+                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
+                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
+                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
+                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
+                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
+                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
+                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
+                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
+                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
+                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+            ],
+            "markers": "python_version < '4' and python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.5.1"
+        },
         "distlib": {
             "hashes": [
                 "sha256:cd502c66fc27c535bab62dc4f482e403e2369c2c05281a79cc2d4e2f42a87f20"
@@ -84,6 +145,14 @@
             "markers": "python_version >= '2.6' and python_version >= '2.7' and python_version < '2.8' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.6"
         },
+        "execnet": {
+            "hashes": [
+                "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
+                "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.5.0"
+        },
         "first": {
             "hashes": [
                 "sha256:3bb3de3582cb27071cfb514f00ed784dc444b7f96dc21e140de65fe00585c95e",
@@ -91,6 +160,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.0.1"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0' and python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.0.2"
         },
         "idna": {
             "hashes": [
@@ -115,6 +192,15 @@
             "markers": "python_version >= '2.6' and python_version >= '3.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.0.0"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.3.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
@@ -125,6 +211,9 @@
         },
         "passa": {
             "editable": true,
+            "extras": [
+                "tests"
+            ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "path": "."
         },
@@ -155,6 +244,22 @@
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.2.2"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.7.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.6.0"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
@@ -162,6 +267,46 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:2d7c49e931316cc7d1638a3e5f54f5d7b4e5225972b3c9838f3584788d27f349",
+                "sha256:ad0c7db7b5d4081631e0155f5c61b80ad76ce148551aaafe3a718d65a7508b18"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.7.4"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.6.0"
+        },
+        "pytest-forked": {
+            "hashes": [
+                "sha256:e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805",
+                "sha256:f275cb48a73fc61a6710726348e1da6d68a978f0ec0c54ece5a5fae5977e5a08"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.2"
+        },
+        "pytest-timeout": {
+            "hashes": [
+                "sha256:1117fc0536e1638862917efbdc0895e6b62fa61e6cf4f39bb655686af7af9627",
+                "sha256:b050a05da96a9992e90e884bc19b4790678b40c25471d2b77015b388417e1fa8"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.3.2"
+        },
+        "pytest-xdist": {
+            "hashes": [
+                "sha256:0875deac20f6d96597036bdf63970887a6f36d28289c2f6682faf652dfea687b",
+                "sha256:28e25e79698b2662b648319d3971c0f9ae0e6500f88258ccb9b153c31110ba9b"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.23.0"
         },
         "requests": {
             "hashes": [
@@ -173,19 +318,19 @@
         },
         "requirementslib": {
             "hashes": [
-                "sha256:7288ec80fa62b78c6193eca85882605c4cdbb60361fc62478bd4a913c0b54400",
-                "sha256:8bb1b156d8b13337eab359273605b036d60735b350019addabb054e8a89a96f6"
+                "sha256:90151d8963f814e17190e067b60e92fb35fd1bc46c99f8dba3d7b0d93a3dd958",
+                "sha256:c3aeaa4e0b80843ba65a68878293e07ea52a8d0706dbba86b02dad6cd20ef2dd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.5"
+            "version": "==1.1.6"
         },
         "resolvelib": {
             "hashes": [
-                "sha256:d52f2c0762deeb2a4cc34a84371a7a5ac85e111bdc69ce9ae729d8d636606ad6",
-                "sha256:eb759d43bbf50de9bf36afb9f6c269fabf9ff49084dbfad4ba67252d134bf4b5"
+                "sha256:6c4c6690b0bdd78bcc002e1a5d1b6abbde58c694a6ea1838f165b20d2c943db7",
+                "sha256:8734e53271ef98f38a2c99324d5e7905bc00c97dc3fc5bb7d83c82a979e71c04"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.2.1"
+            "version": "==0.2.2"
         },
         "scandir": {
             "hashes": [
@@ -220,11 +365,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:618b057b96b488bb858102bdb38dd9d451c0617667031e320efea2392a39bec4",
-                "sha256:6856b5395f7c509baad1911aa3940b3c2fb33f53aff968ed1596c393ccea98e5"
+                "sha256:8ab16e93162fc44d3ad83d2aa29a7140b8f7d996ae1790a73b9a7aed6fb504ac",
+                "sha256:ca181cee7aee805d455628f7c94eb8ae814763769a93e69157f250fe4ebe1926"
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.4.3"
+            "version": "==0.4.4"
         },
         "typing": {
             "hashes": [
@@ -232,7 +377,7 @@
                 "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
                 "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
             ],
-            "markers": "(python_version >= '2.7' and python_version < '2.8') or (python_version >= '3.4' and python_version < '3.5') and python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' or (python_version >= '2.7' and python_version < '2.8') or (python_version >= '3.4' and python_version < '3.5') and python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version < '3.5' and python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' or python_version < '3.5' and python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.6.6"
         },
         "urllib3": {
@@ -311,11 +456,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' or python_version >= '3.6'",
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "babel": {
             "hashes": [
@@ -482,11 +627,11 @@
         },
         "imagesize": {
             "hashes": [
-                "sha256:3620cc0cadba3f7475f9940d22431fc4d407269f1be59ec9b8edcca26440cf18",
-                "sha256:5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315"
+                "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
+                "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "importlib": {
             "hashes": [
@@ -640,11 +785,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d",
-                "sha256:890fe5565400902b0c78b5357004aab1c814115894f4f21370e2433256a3eeec"
+                "sha256:513c425e931a0344944f84ea47f3956be0e416d95acbd897a44970c8d926d5d7",
+                "sha256:e360f048b7dae3f2f2a9a4d067b2dd6b6a015d384d1577c994a43f3f7cbad762"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "pytest-forked": {
             "hashes": [
@@ -695,19 +840,19 @@
         },
         "requirementslib": {
             "hashes": [
-                "sha256:7288ec80fa62b78c6193eca85882605c4cdbb60361fc62478bd4a913c0b54400",
-                "sha256:8bb1b156d8b13337eab359273605b036d60735b350019addabb054e8a89a96f6"
+                "sha256:90151d8963f814e17190e067b60e92fb35fd1bc46c99f8dba3d7b0d93a3dd958",
+                "sha256:c3aeaa4e0b80843ba65a68878293e07ea52a8d0706dbba86b02dad6cd20ef2dd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.5"
+            "version": "==1.1.6"
         },
         "resolvelib": {
             "hashes": [
-                "sha256:d52f2c0762deeb2a4cc34a84371a7a5ac85e111bdc69ce9ae729d8d636606ad6",
-                "sha256:eb759d43bbf50de9bf36afb9f6c269fabf9ff49084dbfad4ba67252d134bf4b5"
+                "sha256:6c4c6690b0bdd78bcc002e1a5d1b6abbde58c694a6ea1838f165b20d2c943db7",
+                "sha256:8734e53271ef98f38a2c99324d5e7905bc00c97dc3fc5bb7d83c82a979e71c04"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.2.1"
+            "version": "==0.2.2"
         },
         "scandir": {
             "hashes": [
@@ -744,11 +889,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:a07050845cc9a2f4026a6035cc8ed795a5ce7be6528bbc82032385c10807dfe7",
-                "sha256:d719de667218d763e8fd144b7fcfeefd8d434a6201f76bf9f0f0c1fa6f47fcdb"
+                "sha256:217a7705adcb573da5bbe1e0f5cab4fa0bd89fd9342c9159121746f593c2d5a4",
+                "sha256:a602513f385f1d5785ff1ca420d9c7eb1a1b63381733b2f0ea8188a391314a86"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.7.8"
+            "version": "==1.7.9"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -773,11 +918,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:618b057b96b488bb858102bdb38dd9d451c0617667031e320efea2392a39bec4",
-                "sha256:6856b5395f7c509baad1911aa3940b3c2fb33f53aff968ed1596c393ccea98e5"
+                "sha256:8ab16e93162fc44d3ad83d2aa29a7140b8f7d996ae1790a73b9a7aed6fb504ac",
+                "sha256:ca181cee7aee805d455628f7c94eb8ae814763769a93e69157f250fe4ebe1926"
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.4.3"
+            "version": "==0.4.4"
         },
         "towncrier": {
             "hashes": [
@@ -807,7 +952,7 @@
                 "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
                 "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
             ],
-            "markers": "(python_version >= '2.7' and python_version < '2.8') or (python_version >= '3.4' and python_version < '3.5') and python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' or (python_version >= '2.7' and python_version < '2.8') or (python_version >= '3.4' and python_version < '3.5') and python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version < '3.5' and python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' or python_version < '3.5' and python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.6.6"
         },
         "urllib3": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     requests
     resolvelib>=0.2.1,!=1.0.0.dev0
     requirementslib>=1.1.1
+    pep517
     six
     vistir>=0.1.4
 

--- a/src/passa/cli/__init__.py
+++ b/src/passa/cli/__init__.py
@@ -47,3 +47,6 @@ def main(argv=None):
         result = f(options)
     if result is not None:
         sys.exit(result)
+
+
+main(argv=["lock", "--project", "/tmp/test"])

--- a/src/passa/internals/_pip.py
+++ b/src/passa/internals/_pip.py
@@ -8,14 +8,20 @@ import os
 
 import setuptools.dist
 
+import distlib.locators
 import distlib.scripts
 import distlib.wheel
+import packaging
+import pep517
 import pip_shims
 import six
 import vistir
 
+from functools import partial
+
 from ._pip_shims import VCS_SUPPORT, build_wheel as _build_wheel, unpack_url
 from .caches import CACHE_DIR
+from .pyproject import load_pyproject_toml
 from .utils import filter_sources
 
 
@@ -128,6 +134,141 @@ def _convert_hashes(values):
     return hashes
 
 
+def get_dist(self):
+    import pkg_resources
+    if self.metadata_directory:
+        base_dir, distinfo = os.path.split(self.metadata_directory)
+        metadata = pkg_resources.PathMetadata(
+            base_dir, self.metadata_directory
+        )
+        dist_name = os.path.splitext(distinfo)[0]
+        type_ = pkg_resources.DistInfoDistribution
+    else:
+        egg_info = self.egg_info_path('').rstrip(os.path.sep)
+        base_dir = os.path.dirname(egg_info)
+        metadata = pkg_resources.PathMetadata(base_dir, egg_info)
+        dist_name = os.path.splitext(os.path.basename(egg_info))[0]
+        type_ = pkg_resources.Distribution
+
+    return type_(
+            base_dir,
+            project_name=dist_name,
+            metadata=metadata,
+        )
+
+
+def _correct_build_location(self):
+    # Correct the metadata directory, if it exists
+    old_location = self._temp_build_dir.path
+    new_location = self.build_location(self._ideal_build_dir)
+    self._orig_build_location_corrector()
+    if self.metadata_directory:
+        old_meta = self.metadata_directory
+        rel = os.path.relpath(old_meta, start=old_location)
+        new_meta = os.path.join(new_location, rel)
+        new_meta = os.path.normpath(os.path.abspath(new_meta))
+        self.metadata_directory = new_meta
+
+
+def prepare_pep517_metadata(self):
+    assert self.pep517_backend is not None
+    metadata_dir = os.path.join(
+        self.setup_py_dir,
+        'pip-wheel-metadata'
+    )
+    os.makedirs(metadata_dir)
+    with self.build_env:
+        # Note that Pep517HookCaller implements a fallback for
+        # prepare_metadata_for_build_wheel, so we don't have to
+        # consider the possibility that this hook doesn't exist.
+        backend = self.pep517_backend
+        distinfo_dir = backend.prepare_metadata_for_build_wheel(
+            metadata_dir
+        )
+    self.metadata_directory = os.path.join(metadata_dir, distinfo_dir)
+
+
+def prepare_metadata(self):
+    import pkg_resources
+    assert self.source_dir
+    if self.use_pep517:
+        self.prepare_pep517_metadata()
+    else:
+        self._run_egg_info()
+    if not self.req:
+        if isinstance(packaging.version.parse(self.metadata["Version"]), packaging.version.Version):
+            op = "=="
+        else:
+            op = "==="
+        self.req = pkg_resources.Requirement(
+            "".join([
+                self.metadata["Name"],
+                op,
+                self.metadata["Version"],
+            ])
+        )
+        self._correct_build_location()
+    else:
+        metadata_name = packaging.utils.canonicalize_name(self.metadata["Name"])
+        self.req = pkg_resources.Requirement(metadata_name)
+
+
+def _patch_ireq(ireq):
+    ireq.metadata_directory = None
+    ireq._orig_build_location_corrector = ireq._correct_build_location
+    ireq._run_egg_info = ireq.run_egg_info
+    ireq.run_egg_info = partial(prepare_metadata, ireq)
+    ireq._correct_build_location = partial(_correct_build_location, ireq)
+    ireq.load_pyproject_toml = partial(_load_pyproject_toml, ireq)
+    ireq.get_dist = partial(get_dist, ireq)
+    ireq.prepare_metadata = partial(prepare_metadata, ireq)
+    return ireq
+
+
+def _load_pyproject_toml(ireq):
+    pep517_data = load_pyproject_toml(
+        ireq.use_pep517,
+        ireq.pyproject_toml,
+        ireq.setup_py,
+        str(ireq)
+    )
+
+    if pep517_data is None:
+        ireq.use_pep517 = False
+    else:
+        ireq.use_pep517 = True
+        requires, backend, check = pep517_data
+        ireq.requirements_to_check = check
+        ireq.pyproject_requires = requires
+        ireq.pep517_backend = pep517.wrappers.Pep517HookCaller(ireq.setup_py_dir, backend)
+
+
+def _load_pyproject(ireq):
+    ireq.use_pep517 = None
+    ireq = _patch_ireq(ireq)
+    return ireq
+
+
+def get_sdist(ireq, sources, hashes=None):
+    kwargs = _prepare_wheel_building_kwargs(ireq)
+    finder = _get_finder(sources)
+    ireq.populate_link(finder, False, False)
+    ireq = _patch_ireq(ireq)
+    ireq.ensure_has_source_dir(kwargs["src_dir"])
+    ireq.use_pep517 = None
+    ireq.load_pyproject_toml()
+    if not ireq.use_pep517 and not ireq.is_wheel:
+        download_dir = kwargs["download_dir"]
+        ireq.options["hashes"] = _convert_hashes(hashes)
+        unpack_url(
+            ireq.link, ireq.source_dir, download_dir,
+            only_download=False, session=finder.session,
+            hashes=ireq.hashes(False), progress_bar=False,
+        )
+        return ireq
+    raise RuntimeError("Failed unpacking sdist %s" % ireq.name)
+
+
 def build_wheel(ireq, sources, hashes=None):
     """Build a wheel file for the InstallRequirement object.
 
@@ -148,6 +289,7 @@ def build_wheel(ireq, sources, hashes=None):
     # when we provide them, because pip skips local wheel cache if we set it
     # to True. Hashes are checked later if we need to download the file.
     ireq.populate_link(finder, False, False)
+    ireq = _patch_ireq(ireq)
 
     # Ensure ireq.source_dir is set.
     # This is intentionally set to build_dir, not src_dir. Comments from pip:
@@ -157,6 +299,9 @@ def build_wheel(ireq, sources, hashes=None):
     # Also see comments in `_prepare_wheel_building_kwargs()` -- If the ireq
     # is editable, build_dir is actually src_dir, making the build in-place.
     ireq.ensure_has_source_dir(kwargs["build_dir"])
+    ireq.use_pep517 = None
+    ireq.load_pyproject_toml()
+    ireq.prepare_metadata()
 
     # Ensure the source is fetched. For wheels, it is enough to just download
     # because we'll use them directly. For an sdist, we need to unpack so we

--- a/src/passa/internals/_pip_shims.py
+++ b/src/passa/internals/_pip_shims.py
@@ -35,6 +35,16 @@ def _build_wheel_modern(ireq, output_dir, finder, wheel_cache, kwargs):
             kwargs["req_tracker"] = req_tracker
         preparer = pip_shims.RequirementPreparer(**kwargs)
         builder = pip_shims.WheelBuilder(finder, preparer, wheel_cache)
+        backend = getattr(ireq, "pep517_backend", None)
+        metadata_directory = getattr(ireq, "metadata_directory", None)
+        if metadata_directory and backend is not None:
+            try:
+                ireq.pep517_backend.build_wheel(
+                    output_dir,
+                    metadata_directory=ireq.metadata_directory
+                )
+            except Exception:
+                return False
         return builder._build_one(ireq, output_dir)
 
 

--- a/src/passa/internals/dependencies.py
+++ b/src/passa/internals/dependencies.py
@@ -6,7 +6,6 @@ import functools
 import os
 import sys
 
-import distlib.metadata
 import packaging.specifiers
 import packaging.utils
 import packaging.version
@@ -227,18 +226,15 @@ def _get_dependencies_from_wheel(ireq, sources):
 
 
 def _get_dependencies_from_pip(ireq, sources):
-    ireq = get_sdist(ireq, sources)
-    egg_info_name = "%s.egg-info" % packaging.utils.canonicalize_name(ireq.name).replace("-", "_")
-    requires_txt_path = os.path.join(ireq.setup_py_dir, egg_info_name, "requires.txt")
-    metadata_path = os.path.join(ireq.setup_py_dir, egg_info_name, "PKG-INFO")
-    requires_python = _read_requires_python(distlib.metadata.Metadata(metadata_path))
-    requirements = []
-    if os.path.exists(requires_txt_path):
-        with open(requires_txt_path, "r") as fh:
-            requirements = [line.strip() for line in fh.readlines() if not line.strip().startswith("[")]
+    dist = get_sdist(ireq, sources)
+    requirements = dist.requires()
     if requirements:
-        requirements = [line for line in requirements if line.strip()]
-        return requirements, requires_python
+        requirements = [
+            requirementslib.Requirement.from_metadata(
+                req.project_name, req.specifier, req.extras, req.marker
+            ).as_line() for req in requirements
+        ]
+        return requirements, ""
     return
 
 

--- a/src/passa/internals/pyproject.py
+++ b/src/passa/internals/pyproject.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+
+import io
+import os
+import pytoml
+import six
+
+
+def _is_list_of_str(obj):
+    return (
+        isinstance(obj, list) and
+        all(isinstance(item, six.string_types) for item in obj)
+    )
+
+
+def load_pyproject_toml(use_pep517, pyproject_toml, setup_py, req_name):
+    """Load the pyproject.toml file.
+
+    Parameters:
+        use_pep517 - Has the user requested PEP 517 processing? None
+                     means the user hasn't explicitly specified.
+        pyproject_toml - Location of the project's pyproject.toml file
+        setup_py - Location of the project's setup.py file
+        req_name - The name of the requirement we're processing (for
+                   error reporting)
+
+    Returns:
+        None if we should use the legacy code path, otherwise a tuple
+        (
+            requirements from pyproject.toml,
+            name of PEP 517 backend,
+            requirements we should check are installed after setting
+                up the build environment
+        )
+    """
+    has_pyproject = os.path.isfile(pyproject_toml)
+    has_setup = os.path.isfile(setup_py)
+
+    if has_pyproject:
+        with io.open(pyproject_toml, encoding="utf-8") as f:
+            pp_toml = pytoml.load(f)
+        build_system = pp_toml.get("build-system")
+    else:
+        build_system = None
+
+    # The following cases must use PEP 517
+    # We check for use_pep517 equalling False because that
+    # means the user explicitly requested --no-use-pep517
+    if has_pyproject and not has_setup:
+        if use_pep517 is False:
+            raise RuntimeError(
+                "Disabling PEP 517 processing is invalid: "
+                "project does not have a setup.py"
+            )
+        use_pep517 = True
+    elif build_system and "build-backend" in build_system:
+        if use_pep517 is False:
+            raise RuntimeError(
+                "Disabling PEP 517 processing is invalid: "
+                "project specifies a build backend of {} "
+                "in pyproject.toml".format(
+                    build_system["build-backend"]
+                )
+            )
+        use_pep517 = True
+
+    # If we haven't worked out whether to use PEP 517 yet,
+    # and the user hasn't explicitly stated a preference,
+    # we do so if the project has a pyproject.toml file.
+    elif use_pep517 is None:
+        use_pep517 = has_pyproject
+
+    # At this point, we know whether we're going to use PEP 517.
+    assert use_pep517 is not None
+
+    # If we're using the legacy code path, there is nothing further
+    # for us to do here.
+    if not use_pep517:
+        return None
+
+    if build_system is None:
+        # Either the user has a pyproject.toml with no build-system
+        # section, or the user has no pyproject.toml, but has opted in
+        # explicitly via --use-pep517.
+        # In the absence of any explicit backend specification, we
+        # assume the setuptools backend, and require wheel and a version
+        # of setuptools that supports that backend.
+        build_system = {
+            "requires": ["setuptools>=38.2.5", "wheel"],
+            "build-backend": "setuptools.build_meta",
+        }
+
+    # If we're using PEP 517, we have build system information (either
+    # from pyproject.toml, or defaulted by the code above).
+    # Note that at this point, we do not know if the user has actually
+    # specified a backend, though.
+    assert build_system is not None
+
+    # Ensure that the build-system section in pyproject.toml conforms
+    # to PEP 518.
+    error_template = (
+        "{package} has a pyproject.toml file that does not comply "
+        "with PEP 518: {reason}"
+    )
+
+    # Specifying the build-system table but not the requires key is invalid
+    if "requires" not in build_system:
+        raise RuntimeError(
+            error_template.format(package=req_name, reason=(
+                "it has a 'build-system' table but not "
+                "'build-system.requires' which is mandatory in the table"
+            ))
+        )
+
+    # Error out if requires is not a list of strings
+    requires = build_system["requires"]
+    if not _is_list_of_str(requires):
+        raise RuntimeError(error_template.format(
+            package=req_name,
+            reason="'build-system.requires' is not a list of strings.",
+        ))
+
+    backend = build_system.get("build-backend")
+    check = []
+    if backend is None:
+        # If the user didn't specify a backend, we assume they want to use
+        # the setuptools backend. But we can't be sure they have included
+        # a version of setuptools which supplies the backend, or wheel
+        # (which is neede by the backend) in their requirements. So we
+        # make a note to check that those requirements are present once
+        # we have set up the environment.
+        # TODO: Review this - it's quite a lot of work to check for a very
+        # specific case. The problem is, that case is potentially quite
+        # common - projects that adopted PEP 518 early for the ability to
+        # specify requirements to execute setup.py, but never considered
+        # needing to mention the build tools themselves. The original PEP
+        # 518 code had a similar check (but implemented in a different
+        # way).
+        backend = "setuptools.build_meta"
+        check = ["setuptools>=38.2.5", "wheel"]
+
+    return (requires, backend, check)


### PR DESCRIPTION
- Adds fallback resolution using sdists when building wheels is not possible (which it is not always possible to do -- see `apache-airflow` for example)
- Adds pep517 builder backend support to the wheel builder process to try to build wheels using their specified backends
- Now fully functional (?)