### PR TITLE
Do not accept requires_dist: null from JSON API

### DIFF
--- a/src/passa/internals/dependencies.py
+++ b/src/passa/internals/dependencies.py
@@ -153,8 +153,7 @@ def _get_dependencies_from_json(ireq, sources):
             if dependencies is not None:
                 return dependencies
         except Exception as e:
-            pass
-        print("unable to read dependencies via {0}".format(url))
+            print("unable to read dependencies via {0} ({1})".format(url, e))
     return
 
 

--- a/src/passa/internals/dependencies.py
+++ b/src/passa/internals/dependencies.py
@@ -91,16 +91,20 @@ def _get_dependencies_from_json_url(url, session):
     except KeyError:
         requirement_lines = info["requires"]
 
-    # The JSON API return null for empty requirements, for some reason, so we
-    # can't just pass it into the comprehension.
-    if not requirement_lines:
-        return [], requires_python
-
-    dependencies = [
-        dep_req.as_line(include_hashes=False) for dep_req in (
+    # The JSON API returns null both when there are not requirements, or the
+    # requirement list cannot be retrieved. We can't safely assume, so it's
+    # better to drop it and fall back to downloading the package.
+    try:
+        dependency_requirements_iterator = (
             requirementslib.Requirement.from_line(line)
             for line in requirement_lines
         )
+    except TypeError:
+        return
+
+    dependencies = [
+        dep_req.as_line(include_hashes=False)
+        for dep_req in dependency_requirements_iterator
         if not contains_extra(dep_req.markers)
     ]
     return dependencies, requires_python


### PR DESCRIPTION
Related to #40. 

This will induce an overhead to packages with empty requirements, and some of those can be quite significant. I can’t think of a better way to work around this quirk, unfortunately.

Some example packages:

* [numpy](https://pypi.org/pypi/numpy/json). It has wheels, so PyPI should be able to read dependencies, but its `requires_dist` is still `null`. In reality it does not have any dependencies at all.
* [apache-airflow](https://pypi.org/pypi/apache-airflow/json). It has tons of dependencies, but PyPI fails to read it, and reports its `requires_dist` as `null`.

So this PR plays it safe and always fall back when JSON reports `null`. The local dependency cache will be relied on to reduce overhead in cases like numpy.